### PR TITLE
Reduce size of the build Docker output

### DIFF
--- a/paperless-ng/Dockerfile
+++ b/paperless-ng/Dockerfile
@@ -1,120 +1,116 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-#Dependencies
+# Dependencies - matches paperless-ng:master Dockerfile
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
-    build-essential \
     curl \
     file \
+    # fonts for test file thumbnail generation
     fonts-liberation \
+    # for making translations further down
     gettext \
-    ghostscript \
     gnupg \
-    icc-profiles-free \
     imagemagick \
-    jq \
+    # for Numpy
     libatlas-base-dev \
-    libffi-dev \
-    libssl-dev \
-    liblept5 \
-    libmagic-dev \
-    libpoppler-cpp-dev \
-    libpq-dev \
-    libqpdf-dev \
-    libxml2 \
-    libxml2-dev \
     libxslt1-dev \
+    mime-support \
     optipng \
-    p7zip-full \
-    pngquant \
-    python3-pip \
-    python3-dev \
-    python3-scipy \
-    qpdf \
     sudo \
+    tzdata \
+    # OCRmyPDF dependencies
+    ghostscript \
+    icc-profiles-free \
+    liblept5 \
+    libxml2 \
+    pngquant \
+    qpdf \
     tesseract-ocr \
     tesseract-ocr-eng \
     tesseract-ocr-deu \
     tesseract-ocr-fra \
     tesseract-ocr-ita \
     tesseract-ocr-spa \
-    tzdata \
     unpaper \
-    unzip \
-    wget \
     zlib1g \
     && mkdir /var/log/supervisord /var/run/supervisord
 
-# Download release of Paperless-ng
-RUN wget -O paperless.tar.xz https://github.com/jonaswinkler/paperless-ng/releases/download/ng-1.1.4/paperless-ng-1.1.4.tar.xz \
+# Download release of Paperless-ng, adding and removing wget/7zip
+RUN apt-get update && apt-get install --no-install-recommends -y wget p7zip-full \
+    && wget -O paperless.tar.xz https://github.com/jonaswinkler/paperless-ng/releases/download/ng-1.1.4/paperless-ng-1.1.4.tar.xz \
     && 7z x paperless.tar.xz \
     && 7z x paperless.tar -o/usr/src/ \
-    && cd /usr/src 
+    && rm paperless.tar.xz paperless.tar \
+    && cd /usr/src \
+    && apt-get -y remove --purge wget p7zip-full \
+    && rm -rf /var/lib/apt/lists/* \
+    # Copy the app to the right place
+    && mkdir -p /usr/src/paperless/src \
+    && cp /usr/src/paperless-ng/requirements.txt /usr/src/paperless/requirements.txt \
+    # copy app
+    && cd /usr/src/paperless-ng \
+    && cp -R ./src /usr/src/paperless/
 
-WORKDIR /usr/src/paperless-ng/
-
-# We need to make the directory before coping to it
-RUN mkdir -p /usr/src/paperless/src
-RUN cp requirements.txt /usr/src/paperless/requirements.txt
-
-# copy app
-RUN cp -R ./src /usr/src/paperless/
-
-
-# Install requirements
-RUN python3 -m pip install --upgrade pip supervisor setuptools \
-    && python3 -m pip install --no-cache-dir -r requirements.txt
+# Install requirements and any temporary tools required 
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    build-essential \
+    libpoppler-cpp-dev \
+    libpq-dev \
+    libqpdf-dev \
+    python3-dev \
+    python3-pip \
+    && python3 -m pip install --upgrade --no-cache-dir pip supervisor setuptools \
+    && cd /usr/src/paperless \
+    && python3 -m pip install --no-cache-dir -r requirements.txt \
+    && apt-get -y purge build-essential libqpdf-dev python3-dev python3-pip \
+    && apt-get -y autoremove --purge \
+    && rm -rf /var/lib/apt/lists/*
 
 #### Redis Setup
-RUN apt-get install redis-server redis-tools -y
-RUN sed -i "s/bind .*/bind 127.0.0.1/g" /etc/redis/redis.conf
+RUN apt-get update && \
+    apt-get install --no-install-recommends python3 redis-server redis-tools -y\
+    && sed -i "s/bind .*/bind 127.0.0.1/g" /etc/redis/redis.conf \
+    && rm -rf /var/lib/apt/lists/*
 
 # Clean Up
-RUN apt-get -y purge build-essential libqpdf-dev \
-    && apt-get -y autoremove --purge \
-    && rm -rf /var/lib/apt/lists/* 
+#RUN apt-get -y purge build-essential libqpdf-dev \
+#    && apt-get -y autoremove --purge \
+#    && rm -rf /var/lib/apt/lists/* 
 
 # copy scripts
 # FROM ORIGINAL DOCKER FILE: this fixes issues with imagemagick and PDF
-RUN cp docker/imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
-RUN cp gunicorn.conf.py /usr/src/paperless
-RUN cp docker/supervisord.conf /etc/supervisord.conf
+RUN cd /usr/src/paperless-ng && \
+    cp docker/imagemagick-policy.xml /etc/ImageMagick-6/policy.xml \
+    && cp gunicorn.conf.py /usr/src/paperless \
+    && cp docker/supervisord.conf /etc/supervisord.conf
 # RUN cp docker/docker-entrypoint.sh /sbin/docker-entrypoint.sh
+
 COPY scripts/docker-entrypoint.sh /sbin/docker-entrypoint.sh
-
-
-WORKDIR /usr/src/paperless
-
-
-
-
-
-WORKDIR /usr/src/paperless
-# add users, setup scripts
-RUN addgroup --gid 1000 paperless \
-    && useradd --uid 1000 --gid paperless --home-dir /usr/src/paperless paperless \
-    && chown -R paperless:paperless . \
-    && chmod 755 /sbin/docker-entrypoint.sh
 
 WORKDIR /usr/src/paperless/src/
 
+# add users, setup scripts
+RUN addgroup --gid 1000 paperless \
+    && useradd --uid 1000 --gid paperless --home-dir /usr/src/paperless paperless \
+    && chown -R paperless:paperless ../ \
+    && chmod 755 /sbin/docker-entrypoint.sh
+
+
 ENV PAPERLESS_REDIS="redis://localhost:6379"
-
 COPY scripts/wait-for-redis.sh scripts/wait-for-redis.sh
-RUN sudo chmod +x scripts/wait-for-redis.sh
 
-RUN sudo -HEu paperless python3 manage.py collectstatic --clear --no-input
+COPY scripts/setup_superuser.py scripts/setup_superuser.py
 
-RUN sudo -HEu paperless python3 manage.py compilemessages
-
+# Prepare the application
+RUN sudo chmod +x scripts/wait-for-redis.sh \
+    && sudo -HEu paperless python3 manage.py collectstatic --clear --no-input \
+    && sudo -HEu paperless python3 manage.py compilemessages
 
 VOLUME ["/usr/src/paperless/data", "/usr/src/paperless/media", "/usr/src/paperless/consume", "/usr/src/paperless/export"]
 
-COPY scripts/setup_superuser.py scripts/setup_superuser.py
 ENTRYPOINT ["/bin/bash", "/sbin/docker-entrypoint.sh"]
 EXPOSE 8000
-
 
 CMD ["/usr/local/bin/supervisord", "-c", "/etc/supervisord.conf"]
 


### PR DESCRIPTION
* Re-arrange the docker file to make it more like the `paperless-ng` Dockerfile. 
* Combine whereever sensible to reduce the number of layers.
* Remove anything we don't need immediately after using it.